### PR TITLE
Theme: follow system light/dark + fix white iOS Safari bars

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -273,6 +273,7 @@ const projects = [
   /* ---------------- Palettes ---------------- */
   :root,
   :root[data-theme="light"] {
+    color-scheme: light;
     --surface: #e9e6e1;
     --shd: #cdc9c2;
     --shl: #fbf9f5;
@@ -286,6 +287,7 @@ const projects = [
     --on-accent: #fbf9f5;
   }
   :root[data-theme="dark"] {
+    color-scheme: dark;
     --surface: #262320;
     --shd: #1a1714;
     --shl: #322e29;
@@ -300,8 +302,10 @@ const projects = [
   }
 
   * { box-sizing: border-box; }
-  html { scroll-behavior: smooth; }
-  body { margin: 0; }
+  /* Paint the full viewport (incl. iOS Safari bars & overscroll) with the
+     surface color, not just the inner .root element. */
+  html { scroll-behavior: smooth; background: var(--surface); }
+  body { margin: 0; background: var(--surface); transition: background 0.35s ease; }
   a { color: inherit; }
 
   @keyframes spin { to { transform: rotate(360deg); } }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,11 +53,13 @@ const projects = [
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;700&display=swap" rel="stylesheet" />
 
-  {/* Apply saved theme before first paint to avoid a flash. */}
+  {/* Apply the theme before first paint to avoid a flash.
+      Use the saved choice if there is one, otherwise follow the OS setting. */}
   <script is:inline>
     (function () {
       try {
-        var t = localStorage.getItem("hr-theme") || "light";
+        var stored = localStorage.getItem("hr-theme");
+        var t = stored || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
         document.documentElement.dataset.theme = t;
       } catch (e) {}
     })();
@@ -234,19 +236,34 @@ const projects = [
     (function () {
       var btn = document.getElementById("themeToggle");
       var icon = btn && btn.querySelector("[data-theme-icon]");
+      var meta = document.querySelector('meta[name="theme-color"]');
+      var COLORS = { light: "#e9e6e1", dark: "#262320" };
       function sync() {
-        var dark = document.documentElement.dataset.theme === "dark";
-        if (icon) icon.textContent = dark ? "☀" : "☾";
+        var theme = document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+        if (icon) icon.textContent = theme === "dark" ? "☀" : "☾";
+        if (meta) meta.setAttribute("content", COLORS[theme]);
       }
       sync();
       if (btn) {
         btn.addEventListener("click", function () {
           var next = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
           document.documentElement.dataset.theme = next;
+          // Manual choice becomes sticky and overrides the OS setting.
           try { localStorage.setItem("hr-theme", next); } catch (e) {}
           sync();
         });
       }
+      // Keep following the OS until the user makes an explicit choice.
+      try {
+        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function (e) {
+          var stored = null;
+          try { stored = localStorage.getItem("hr-theme"); } catch (err) {}
+          if (!stored) {
+            document.documentElement.dataset.theme = e.matches ? "dark" : "light";
+            sync();
+          }
+        });
+      } catch (e) {}
     })();
   </script>
 </body>


### PR DESCRIPTION
These two changes were pushed to `redesign-astro` **after** PR #3 was squash-merged, so they never reached `main`/production. This re-applies them on top of `main`.

### 1. Default theme to the system `prefers-color-scheme`
- With no saved choice, the site uses the OS light/dark setting, resolved before first paint (no flash).
- The manual toggle still overrides and persists; the page live-updates on OS theme changes while no explicit choice is set.
- Verified all three branches (OS dark, OS light, manual-override-wins) via Chrome DevTools `prefers-color-scheme` emulation.

### 2. Fix white iOS Safari bars
- Only the inner `.root` element was painted, so `html`/`body` stayed default white and Safari tinted its top/bottom bars white.
- Now paints `html`/`body` with `var(--surface)` and declares `color-scheme: light`/`dark` per theme, so the native UI (bars, overscroll, scrollbars) matches the active theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)