### PR TITLE
CI: surface Lighthouse as its own PR check

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -7,6 +7,9 @@ jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
+    # Expose the preview channel URL so the lighthouse job can target it.
+    outputs:
+      preview_url: '${{ steps.deploy.outputs.details_url }}'
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -21,10 +24,32 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_HASSANALRAWI_EB46F }}'
           projectId: hassanalrawi-eb46f
-      - name: Run Lighthouse against the preview URL
+
+  # Separate job so Lighthouse shows up as its own check in the PR, with a
+  # report link surfaced in the run summary (rather than buried in deploy logs).
+  lighthouse:
+    needs: build_and_preview
+    if: "${{ needs.build_and_preview.outputs.preview_url != '' }}"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: lhci
+        name: Run Lighthouse against the preview URL
         uses: treosh/lighthouse-ci-action@v12
         with:
-          urls: '${{ steps.deploy.outputs.details_url }}'
+          urls: '${{ needs.build_and_preview.outputs.preview_url }}'
           configPath: ./.github/lighthouse/lighthouserc.json
           uploadArtifacts: true
           temporaryPublicStorage: true
+      - name: Publish report link to the run summary
+        if: always()
+        run: |
+          {
+            echo "## Lighthouse"
+            echo "Preview: ${{ needs.build_and_preview.outputs.preview_url }}"
+            echo ""
+            echo "Report links:"
+            echo '```json'
+            echo '${{ steps.lhci.outputs.links }}'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

Lighthouse **was already running** on PRs — but as a *step inside* the `build_and_preview` job, so it never showed up as a distinct check in the PR's checks list, and the report link was buried in the deploy job's logs. (Confirmed: it ran and passed in PR #8.)

## What changed

- `build_and_preview` now exposes the Firebase preview URL as a **job output** (`preview_url`).
- A new **`lighthouse` job** (`needs: build_and_preview`) runs Lighthouse against that URL, so it appears as its own **"lighthouse" check** in the PR.
- The job writes the Lighthouse report link(s) to the **run summary**, so you can open the report without digging through logs.
- Guarded with `if: preview_url != ''` so it skips cleanly when there's no preview (e.g. fork PRs where the deploy is skipped).

This PR itself should now show a separate **lighthouse** check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)