### PR TITLE
UI tweaks: tag spacing, stack chip layout, add AI

### DIFF
--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -46,7 +46,7 @@ export const stack: string[] = [
   "TypeScript", "Go", "React", "Next.js", "Node", "PostgreSQL",
   "GraphQL", "AWS", "Docker", "Python",
   "React Native", "Flutter", ".NET", "C#", "Kotlin", "Terraform",
-  "SQL", "Snowflake", "Twilio", "Sentry", "And so much more…",
+  "SQL", "Snowflake", "Twilio", "Sentry", "AI", "And so much more…",
 ];
 
 export interface Discipline {

--- a/src/styles/selected-work.css
+++ b/src/styles/selected-work.css
@@ -25,6 +25,8 @@
 .work-view { text-decoration: none; font-size: 12.5px; font-weight: 700; color: var(--accent); }
 .work-view--soon { color: var(--dim); }
 .work-blurb { font-size: 13.5px; line-height: 1.55; color: var(--dim); margin: 0 0 14px; }
+/* Space the tag pills so they don't butt up against each other. */
+.tags { display: flex; flex-wrap: wrap; gap: 8px; }
 
 @media (max-width: 760px) {
   .work { grid-template-columns: 1fr; }

--- a/src/styles/stack.css
+++ b/src/styles/stack.css
@@ -1,3 +1,5 @@
 /* Tech-stack chip row. (Chips use .chip from utilities.) */
 .stack-section { margin-bottom: 64px; scroll-margin-top: 24px; }
-.chips { display: flex; flex-wrap: wrap; gap: 10px; }
+.chips { display: flex; flex-wrap: wrap; gap: 10px; justify-content: center; }
+/* Let the trailing "And so much more…" chip fill the rest of its row. */
+.chips .chip:last-child { flex: 1; text-align: center; }


### PR DESCRIPTION
## Changes

- **Project tags spacing** — the tag pills (Web / Mobile / tvOS) had no container styling, so they sat flush against each other. Added a `.tags` flex container with `gap: 8px` and wrapping.
- **Stack chips centered** — `justify-content: center` on the `.chips` row.
- **Full-width trailing chip** — the last chip ("And so much more…") now `flex: 1` so it fills the rest of its row, centered.
- **Added "AI"** to the *What I use* stack (before the trailing chip).

Build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)